### PR TITLE
V0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.8] - 2025-12-03
+
+- Updated Dispatcher API endpoint: switched from dev3 to dev1.
+
 ## [0.3.7] - 2025-12-01
 
 - Fixed the issue where the "AI is analyzing" message would persist when no search results were found.

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -15,8 +15,8 @@ server {
 
     # Proxy Player API requests to EOSC Player
     location /player-api/ {
-        proxy_pass https://dev3.player.eosc-data-commons.eu/;
-        proxy_set_header Host dev3.player.eosc-data-commons.eu;
+        proxy_pass https://dev1.player.eosc-data-commons.eu/;
+        proxy_set_header Host dev1.player.eosc-data-commons.eu;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "matchmaker-frontend",
   "private": true,
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/dispatcherApi.ts
+++ b/src/lib/dispatcherApi.ts
@@ -9,7 +9,7 @@ import {
 import {fetchWithTimeout} from './utils';
 
 // Use proxy in development to avoid CORS issues
-const API_BASE = import.meta.env.DEV ? '/player-api' : 'https://dev3.player.eosc-data-commons.eu';
+const API_BASE = import.meta.env.DEV ? '/player-api' : 'https://dev1.player.eosc-data-commons.eu';
 const METADATA_ENDPOINT = '/anon_requests/metadata_rocrate/';
 const FILEMETRIX_BASE = 'https://filemetrix.labs.dansdemo.nl/api/v1';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(() => ({
                 rewrite: (path) => path.replace(/^\/api/, '')
             },
             '/player-api': {
-                target: 'https://dev3.player.eosc-data-commons.eu',
+                target: 'https://dev1.player.eosc-data-commons.eu',
                 changeOrigin: true,
                 secure: false,
                 rewrite: (path) => path.replace(/^\/player-api/, '')


### PR DESCRIPTION
This pull request updates the Dispatcher API endpoint throughout the codebase, switching it from `dev3` to `dev1`. This change affects both the backend proxy configuration and the frontend API calls, ensuring consistency and alignment with the new environment. The version number is also incremented to reflect this update.

API endpoint migration:

* Updated the Dispatcher API endpoint from `dev3.player.eosc-data-commons.eu` to `dev1.player.eosc-data-commons.eu` in the proxy configuration in `nginx.dev.conf` and in the Vite development server configuration in `vite.config.ts`. [[1]](diffhunk://#diff-3f9bd601aa7a257432b186b7c90fe1b6df19b6d22609709a0aab24491fcb12d9L18-R19) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL18-R18)
* Changed the API base URL in the frontend code (`src/lib/dispatcherApi.ts`) to use `dev1` instead of `dev3` for production requests.

Release management:

* Bumped the project version from `0.3.7` to `0.3.8` in `package.json` and documented the API endpoint update in `CHANGELOG.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8)