### PR TITLE
Refactor filter logic to support dynamic aggregation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2025-12-18
+
+- Refactored filter management: filter options now update dynamically based on currently selected filters for more
+  accurate and responsive filtering
+
 ## [0.4.0] - 2025-12-17
 
 - Added local filtering and aggregation utilities for faster, client-side dataset filtering

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "matchmaker-frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useCombinedDatasets.ts
+++ b/src/hooks/useCombinedDatasets.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 import type {BackendSearchResponse, BackendDataset, Aggregations} from '../types/commons';
-import {generateLocalFilters} from '../lib/localFilters';
+import {generateDynamicFilters} from '../lib/localFilters';
 
 interface UseCombinedDatasetsReturn {
     allCombinedDatasets: BackendDataset[];
@@ -9,7 +9,8 @@ interface UseCombinedDatasetsReturn {
 
 export const useCombinedDatasets = (
     initialResults: BackendSearchResponse | null,
-    rerankedResults: BackendSearchResponse | null
+    rerankedResults: BackendSearchResponse | null,
+    activeFilters: URLSearchParams
 ): UseCombinedDatasetsReturn => {
     // Combine all datasets from both result sets
     const allCombinedDatasets = useMemo(() => {
@@ -34,14 +35,14 @@ export const useCombinedDatasets = (
         return Array.from(datasetsMap.values());
     }, [rerankedResults, initialResults]);
 
-    // Generate local filters from ALL combined results
+    // Generate dynamic filters that recalculate based on active filters
     const aggregations: Aggregations = useMemo(() => {
         if (allCombinedDatasets.length === 0) {
             return {};
         }
 
-        return generateLocalFilters(allCombinedDatasets);
-    }, [allCombinedDatasets]);
+        return generateDynamicFilters(allCombinedDatasets, activeFilters);
+    }, [allCombinedDatasets, activeFilters]);
 
     return {
         allCombinedDatasets,

--- a/src/hooks/useFilteredDatasets.ts
+++ b/src/hooks/useFilteredDatasets.ts
@@ -1,10 +1,8 @@
 import {useMemo} from 'react';
-import {useSearchParams} from 'react-router-dom';
 import type {BackendSearchResponse, BackendDataset} from '../types/commons';
 import {applyLocalFilters} from '../lib/localFilters';
 
 interface UseFilteredDatasetsReturn {
-    activeFilters: URLSearchParams;
     filteredDatasets: BackendDataset[];
     filteredRerankedDatasets: BackendDataset[] | null;
     filteredInitialDatasets: BackendDataset[] | null;
@@ -14,20 +12,9 @@ interface UseFilteredDatasetsReturn {
 export const useFilteredDatasets = (
     allCombinedDatasets: BackendDataset[],
     initialResults: BackendSearchResponse | null,
-    rerankedResults: BackendSearchResponse | null
+    rerankedResults: BackendSearchResponse | null,
+    activeFilters: URLSearchParams
 ): UseFilteredDatasetsReturn => {
-    const [searchParams] = useSearchParams();
-
-    // Get active filter params (excluding 'q' and 'model')
-    const activeFilters = useMemo(() => {
-        const filters = new URLSearchParams();
-        searchParams.forEach((value, key) => {
-            if (key !== 'q' && key !== 'model') {
-                filters.append(key, value);
-            }
-        });
-        return filters;
-    }, [searchParams]);
 
     // Apply filters to ALL combined datasets
     const filteredDatasets = useMemo(() => {
@@ -62,7 +49,6 @@ export const useFilteredDatasets = (
     }, [filteredRerankedDatasets, filteredInitialDatasets, rerankedResults]);
 
     return {
-        activeFilters,
         filteredDatasets,
         filteredRerankedDatasets,
         filteredInitialDatasets,

--- a/src/lib/localFilters.ts
+++ b/src/lib/localFilters.ts
@@ -187,3 +187,91 @@ export const applyLocalFilters = (
         return true;
     });
 };
+
+/**
+ * Apply partial filters to datasets for dynamic filter recalculation
+ * Excludes a specific filter key to show what would be available if that filter was changed
+ */
+export const applyPartialFilters = (
+    datasets: BackendDataset[],
+    filters: URLSearchParams,
+    excludeKey: string
+): BackendDataset[] => {
+    const selectedYears = filters.getAll('publicationYear');
+    const selectedAuthors = filters.getAll('creator');
+    const selectedSubjects = filters.getAll('subject');
+
+    return datasets.filter(dataset => {
+        // Apply year filter unless we're calculating aggregations for the year filter
+        if (excludeKey !== 'publicationYear' && selectedYears.length > 0) {
+            let publicationDate = dataset.publication_date;
+            if (!publicationDate && dataset._source?.publicationYear) {
+                publicationDate = dataset._source.publicationYear;
+            }
+            const year = publicationDate ? extractYear(publicationDate) : null;
+
+            if (!year || !selectedYears.includes(year)) {
+                return false;
+            }
+        }
+
+        // Apply author filter unless we're calculating aggregations for the author filter
+        if (excludeKey !== 'creator' && selectedAuthors.length > 0) {
+            const creators = dataset._source.creators || [];
+            const hasMatchingAuthor = creators.some(creator =>
+                selectedAuthors.includes(creator.creatorName?.trim())
+            );
+            if (!hasMatchingAuthor) {
+                return false;
+            }
+        }
+
+        // Apply subject filter unless we're calculating aggregations for the subject filter
+        if (excludeKey !== 'subject' && selectedSubjects.length > 0) {
+            const subjects = dataset._source.subjects || [];
+            const hasMatchingSubject = subjects.some(subj =>
+                selectedSubjects.includes(subj.subject?.trim())
+            );
+            if (!hasMatchingSubject) {
+                return false;
+            }
+        }
+
+        return true;
+    });
+};
+
+/**
+ * Generate dynamic local filters based on currently filtered datasets
+ * Each filter's options are calculated based on datasets that match OTHER filters
+ */
+export const generateDynamicFilters = (
+    allDatasets: BackendDataset[],
+    activeFilters: URLSearchParams
+): Aggregations => {
+    const aggregations: Aggregations = {};
+
+    // For each filter type, calculate aggregations from datasets that match OTHER filters
+    // This creates a dynamic filtering experience where counts update based on selections
+
+    const datasetsForYearFilter = applyPartialFilters(allDatasets, activeFilters, 'publicationYear');
+    const yearAggregation = generateLocalFilters(datasetsForYearFilter);
+    if (yearAggregation.publicationYear) {
+        aggregations.publicationYear = yearAggregation.publicationYear;
+    }
+
+    const datasetsForCreatorFilter = applyPartialFilters(allDatasets, activeFilters, 'creator');
+    const creatorAggregation = generateLocalFilters(datasetsForCreatorFilter);
+    if (creatorAggregation.creator) {
+        aggregations.creator = creatorAggregation.creator;
+    }
+
+    const datasetsForSubjectFilter = applyPartialFilters(allDatasets, activeFilters, 'subject');
+    const subjectAggregation = generateLocalFilters(datasetsForSubjectFilter);
+    if (subjectAggregation.subject) {
+        aggregations.subject = subjectAggregation.subject;
+    }
+
+    return aggregations;
+};
+

--- a/src/lib/localFilters.ts
+++ b/src/lib/localFilters.ts
@@ -1,76 +1,6 @@
 import type {BackendDataset, Aggregations, AggregationBucket} from '../types/commons';
 
 /**
- * Generate local filters (aggregations) from search results
- * Creates filters for publication date (by year), authors, and subjects
- */
-export const generateLocalFilters = (datasets: BackendDataset[]): Aggregations => {
-    const dateMap = new Map<string, number>();
-    const authorMap = new Map<string, number>();
-    const subjectMap = new Map<string, number>();
-
-    datasets.forEach((dataset) => {
-        // Extract publication date/year
-        let publicationDate = dataset.publication_date;
-        if (!publicationDate && dataset._source?.publicationYear) {
-            publicationDate = dataset._source.publicationYear;
-        }
-
-        if (publicationDate) {
-            // Extract year from date
-            const year = extractYear(publicationDate);
-            if (year) {
-                dateMap.set(year, (dateMap.get(year) || 0) + 1);
-            }
-        }
-
-        // Extract authors/creators
-        const creators = dataset._source.creators || [];
-        creators.forEach(creator => {
-            const name = creator.creatorName?.trim();
-            if (name) {
-                authorMap.set(name, (authorMap.get(name) || 0) + 1);
-            }
-        });
-
-        // Extract subjects
-        const subjects = dataset._source.subjects || [];
-        subjects.forEach(subj => {
-            const subject = subj.subject?.trim();
-            if (subject) {
-                subjectMap.set(subject, (subjectMap.get(subject) || 0) + 1);
-            }
-        });
-    });
-
-    const dateBuckets = mapToBuckets(dateMap, true); // Sort dates descending (newest first)
-    const authorBuckets = mapToBuckets(authorMap, false, 20); // Limit to top 20 authors
-    const subjectBuckets = mapToBuckets(subjectMap, false, 15); // Limit to top 15 subjects
-
-
-    const aggregations: Aggregations = {};
-    if (dateBuckets.length > 0) {
-        aggregations.publicationYear = {
-            label: 'Publication Year',
-            buckets: dateBuckets
-        };
-    }
-    if (authorBuckets.length > 0) {
-        aggregations.creator = {
-            label: 'Author',
-            buckets: authorBuckets
-        };
-    }
-    if (subjectBuckets.length > 0) {
-        aggregations.subject = {
-            label: 'Subject',
-            buckets: subjectBuckets
-        };
-    }
-    return aggregations;
-};
-
-/**
  * Extract year from a date string (YYYY-MM-DD) or year string (YYYY)
  */
 const extractYear = (dateStr: string | null | undefined): string | null => {
@@ -134,10 +64,14 @@ const mapToBuckets = (
 /**
  * Apply local filters to datasets
  * Returns filtered array based on selected filter values
+ * @param datasets - Array of datasets to filter
+ * @param filters - URL search params containing filter selections
+ * @param excludeKey - Optional filter key to exclude from filtering (used for dynamic filter recalculation)
  */
 export const applyLocalFilters = (
     datasets: BackendDataset[],
-    filters: URLSearchParams
+    filters: URLSearchParams,
+    excludeKey?: string
 ): BackendDataset[] => {
     const selectedYears = filters.getAll('publicationYear');
     const selectedAuthors = filters.getAll('creator');
@@ -149,60 +83,7 @@ export const applyLocalFilters = (
     }
 
     return datasets.filter(dataset => {
-
-        if (selectedYears.length > 0) {
-            let publicationDate = dataset.publication_date;
-            if (!publicationDate && dataset._source?.publicationYear) {
-                publicationDate = dataset._source.publicationYear;
-            }
-            const year = publicationDate ? extractYear(publicationDate) : null;
-
-            if (!year || !selectedYears.includes(year)) {
-                return false;
-            }
-        }
-
-
-        if (selectedAuthors.length > 0) {
-            const creators = dataset._source.creators || [];
-            const hasMatchingAuthor = creators.some(creator =>
-                selectedAuthors.includes(creator.creatorName?.trim())
-            );
-            if (!hasMatchingAuthor) {
-                return false;
-            }
-        }
-
-
-        if (selectedSubjects.length > 0) {
-            const subjects = dataset._source.subjects || [];
-            const hasMatchingSubject = subjects.some(subj =>
-                selectedSubjects.includes(subj.subject?.trim())
-            );
-            if (!hasMatchingSubject) {
-                return false;
-            }
-        }
-
-        return true;
-    });
-};
-
-/**
- * Apply partial filters to datasets for dynamic filter recalculation
- * Excludes a specific filter key to show what would be available if that filter was changed
- */
-export const applyPartialFilters = (
-    datasets: BackendDataset[],
-    filters: URLSearchParams,
-    excludeKey: string
-): BackendDataset[] => {
-    const selectedYears = filters.getAll('publicationYear');
-    const selectedAuthors = filters.getAll('creator');
-    const selectedSubjects = filters.getAll('subject');
-
-    return datasets.filter(dataset => {
-        // Apply year filter unless we're calculating aggregations for the year filter
+        // Apply year filter unless it's excluded
         if (excludeKey !== 'publicationYear' && selectedYears.length > 0) {
             let publicationDate = dataset.publication_date;
             if (!publicationDate && dataset._source?.publicationYear) {
@@ -215,7 +96,7 @@ export const applyPartialFilters = (
             }
         }
 
-        // Apply author filter unless we're calculating aggregations for the author filter
+        // Apply author filter unless it's excluded
         if (excludeKey !== 'creator' && selectedAuthors.length > 0) {
             const creators = dataset._source.creators || [];
             const hasMatchingAuthor = creators.some(creator =>
@@ -226,7 +107,7 @@ export const applyPartialFilters = (
             }
         }
 
-        // Apply subject filter unless we're calculating aggregations for the subject filter
+        // Apply subject filter unless it's excluded
         if (excludeKey !== 'subject' && selectedSubjects.length > 0) {
             const subjects = dataset._source.subjects || [];
             const hasMatchingSubject = subjects.some(subj =>
@@ -240,36 +121,95 @@ export const applyPartialFilters = (
         return true;
     });
 };
-
 /**
- * Generate dynamic local filters based on currently filtered datasets
+ * Generate dynamic local filters based on dataset collection
  * Each filter's options are calculated based on datasets that match OTHER filters
+ * Optimized to perform a single pass through the dataset
+ * @param datasets - Complete collection of datasets to analyze
+ * @param activeFilters - Currently active filter selections from URL params
+ * @returns Aggregations with dynamically calculated filter options and counts
  */
 export const generateDynamicFilters = (
-    allDatasets: BackendDataset[],
+    datasets: BackendDataset[],
     activeFilters: URLSearchParams
 ): Aggregations => {
+    const selectedYears = activeFilters.getAll('publicationYear');
+    const selectedAuthors = activeFilters.getAll('creator');
+    const selectedSubjects = activeFilters.getAll('subject');
+
+    // Maps to accumulate counts for each filter type
+    const yearMap = new Map<string, number>();
+    const authorMap = new Map<string, number>();
+    const subjectMap = new Map<string, number>();
+
+    datasets.forEach(dataset => {
+        let publicationDate = dataset.publication_date;
+        if (!publicationDate && dataset._source?.publicationYear) {
+            publicationDate = dataset._source.publicationYear;
+        }
+        const year = publicationDate ? extractYear(publicationDate) : null;
+
+        const creators = dataset._source.creators || [];
+        const subjects = dataset._source.subjects || [];
+
+        // Check if dataset matches filters (for each aggregation type)
+        const matchesAuthorFilter = selectedAuthors.length === 0 ||
+            creators.some(creator => selectedAuthors.includes(creator.creatorName?.trim()));
+
+        const matchesSubjectFilter = selectedSubjects.length === 0 ||
+            subjects.some(subj => selectedSubjects.includes(subj.subject?.trim()));
+
+        const matchesYearFilter = selectedYears.length === 0 ||
+            (year && selectedYears.includes(year));
+
+        if (matchesAuthorFilter && matchesSubjectFilter && year) {
+            yearMap.set(year, (yearMap.get(year) || 0) + 1);
+        }
+
+        if (matchesYearFilter && matchesSubjectFilter) {
+            creators.forEach(creator => {
+                const name = creator.creatorName?.trim();
+                if (name) {
+                    authorMap.set(name, (authorMap.get(name) || 0) + 1);
+                }
+            });
+        }
+
+        if (matchesYearFilter && matchesAuthorFilter) {
+            subjects.forEach(subj => {
+                const subject = subj.subject?.trim();
+                if (subject) {
+                    subjectMap.set(subject, (subjectMap.get(subject) || 0) + 1);
+                }
+            });
+        }
+    });
+
+    // Convert maps to aggregation buckets
     const aggregations: Aggregations = {};
 
-    // For each filter type, calculate aggregations from datasets that match OTHER filters
-    // This creates a dynamic filtering experience where counts update based on selections
-
-    const datasetsForYearFilter = applyPartialFilters(allDatasets, activeFilters, 'publicationYear');
-    const yearAggregation = generateLocalFilters(datasetsForYearFilter);
-    if (yearAggregation.publicationYear) {
-        aggregations.publicationYear = yearAggregation.publicationYear;
+    const yearBuckets = mapToBuckets(yearMap, true);
+    if (yearBuckets.length > 0) {
+        aggregations.publicationYear = {
+            label: 'Publication Year',
+            buckets: yearBuckets
+        };
     }
 
-    const datasetsForCreatorFilter = applyPartialFilters(allDatasets, activeFilters, 'creator');
-    const creatorAggregation = generateLocalFilters(datasetsForCreatorFilter);
-    if (creatorAggregation.creator) {
-        aggregations.creator = creatorAggregation.creator;
+    const authorBuckets = mapToBuckets(authorMap, false, 20);
+    if (authorBuckets.length > 0) {
+        aggregations.creator = {
+            label: 'Author',
+            buckets: authorBuckets
+        };
     }
 
-    const datasetsForSubjectFilter = applyPartialFilters(allDatasets, activeFilters, 'subject');
-    const subjectAggregation = generateLocalFilters(datasetsForSubjectFilter);
-    if (subjectAggregation.subject) {
-        aggregations.subject = subjectAggregation.subject;
+    const subjectBuckets = mapToBuckets(subjectMap, false, 15);
+    if (subjectBuckets.length > 0) {
+        aggregations.subject = {
+            label: 'Subject',
+            buckets: subjectBuckets
+        };
     }
 
     return aggregations;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import {useNavigate, useSearchParams} from "react-router-dom";
-import {useEffect, useState} from "react";
+import {useEffect, useState, useMemo} from "react";
 import {XCircleIcon, ChevronDown, ChevronUp, Sparkles} from "lucide-react";
 import {SearchInput} from "../components/SearchInput.tsx";
 import {SearchResultItem} from "../components/SearchResultItem.tsx";
@@ -32,14 +32,25 @@ export const SearchPage = () => {
         performSearch
     } = useSearchResults(query, model);
 
-    const {allCombinedDatasets, aggregations} = useCombinedDatasets(initialResults, rerankedResults);
+    // Extract active filters from URL params
+    const activeFilters = useMemo(() => {
+        const filters = new URLSearchParams();
+        searchParams.forEach((value, key) => {
+            if (key !== 'q' && key !== 'model') {
+                filters.append(key, value);
+            }
+        });
+        return filters;
+    }, [searchParams]);
+
+    const {allCombinedDatasets, aggregations} = useCombinedDatasets(initialResults, rerankedResults, activeFilters);
 
     const {
-        activeFilters,
         filteredRerankedDatasets,
         filteredInitialDatasets,
         datasets
-    } = useFilteredDatasets(allCombinedDatasets, initialResults, rerankedResults);
+    } = useFilteredDatasets(allCombinedDatasets, initialResults, rerankedResults, activeFilters);
+
 
     // Trigger search when query or model changes
     useEffect(() => {


### PR DESCRIPTION
This pull request refactors how filters are managed and applied in the dataset search functionality, improving the dynamic recalculation of filter options and cleaning up filter state handling. The most significant changes include introducing dynamic filter generation based on currently active filters, removing redundant filter logic from hooks, and centralizing filter extraction in the `SearchPage` component.

### Dynamic filter recalculation

* Added `generateDynamicFilters` and `applyPartialFilters` functions in `localFilters.ts` to compute filter aggregations dynamically, so filter options update based on currently selected filters. This enables a more responsive and accurate filtering experience for users.

### Refactoring hooks to accept active filters

* Updated `useCombinedDatasets` and `useFilteredDatasets` hooks to accept `activeFilters` as a parameter instead of extracting them internally, making the hooks more reusable and decoupled from URL state. [[1]](diffhunk://#diff-8d953b2b254141a8b54f7f0f2ed37a84fbe3395ed4bf422ae6ec270d1c963487L12-R13) [[2]](diffhunk://#diff-e61e78c19b17df31d91802ac230f4c82cc9dc1b836b5b8377ccfc5f9fd58ec76L17-L30)
* Removed the internal extraction of filters from URL parameters in `useFilteredDatasets`, simplifying its logic. [[1]](diffhunk://#diff-e61e78c19b17df31d91802ac230f4c82cc9dc1b836b5b8377ccfc5f9fd58ec76L17-L30) [[2]](diffhunk://#diff-e61e78c19b17df31d91802ac230f4c82cc9dc1b836b5b8377ccfc5f9fd58ec76L65)

### Centralizing filter extraction

* Moved the logic for extracting active filters from URL search parameters to the `SearchPage` component, ensuring a single source of truth and reducing duplication. The `activeFilters` object is now computed once and passed down to relevant hooks.

### Updating filter generation and usage

* Replaced the old `generateLocalFilters` call with `generateDynamicFilters` in `useCombinedDatasets`, ensuring that filter aggregations are recalculated based on the current set of active filters. [[1]](diffhunk://#diff-8d953b2b254141a8b54f7f0f2ed37a84fbe3395ed4bf422ae6ec270d1c963487L3-R3) [[2]](diffhunk://#diff-8d953b2b254141a8b54f7f0f2ed37a84fbe3395ed4bf422ae6ec270d1c963487L37-R45)

These changes collectively make the filter system more robust, maintainable, and user-friendly by ensuring filter options always reflect the current filtering context.