### PR TITLE
Add tooltips to AI and OpenSearch scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.2] - 2025-12-22
+
+- Enhanced search result score badges with informative tooltips
+
 ## [0.4.1] - 2025-12-18
 
 - Refactored filter management: filter options now update dynamically based on currently selected filters for more

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "matchmaker-frontend",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -92,7 +92,10 @@ export const SearchResultItem = ({hit, isAiRanked = false}: SearchResultItemProp
                     {hit.title}
                 </h3>
                 {isAiRanked && hit.score !== undefined && (
-                    <div className="flex-shrink-0 flex items-center space-x-1 bg-yellow-50 px-2 py-1 rounded-full">
+                    <div
+                        className="flex-shrink-0 flex items-center space-x-1 bg-yellow-50 px-2 py-1 rounded-full cursor-help"
+                        title="AI-powered relevance score: Ranked by LLM based on semantic understanding of your query. Scores range from 0% (low relevance) to 100% (high relevance)."
+                    >
                         <ProportionalStar percent={scorePercent} className="h-4 w-4"/>
                         <span className="text-sm font-medium text-yellow-700">
                             {scorePercent.toFixed(0)}%
@@ -100,7 +103,10 @@ export const SearchResultItem = ({hit, isAiRanked = false}: SearchResultItemProp
                     </div>
                 )}
                 {!isAiRanked && typeof hit._score === 'number' && !Number.isNaN(hit._score) && (
-                    <div className="flex-shrink-0 flex items-center space-x-1 bg-blue-50 px-2 py-1 rounded-full">
+                    <div
+                        className="flex-shrink-0 flex items-center space-x-1 bg-blue-50 px-2 py-1 rounded-full cursor-help"
+                        title="OpenSearch relevance score: Based on keyword matching and text analysis. Scores range from 0% (low match) to 100% (high match)."
+                    >
                         <ProportionalStar percent={(hit._score || 0) * 100} className="h-4 w-4" color="#005EB8"/>
                         <span className="text-sm font-semibold" style={{color: '#005EB8'}}>
                             {(((hit._score || 0) * 100)).toFixed(0)}%


### PR DESCRIPTION
This pull request improves the user experience by adding helpful tooltips to the search result score badges in the `SearchResultItem` component. Now, when users hover over the AI-powered or OpenSearch score badges, they will see an explanation of what the score means.

Enhancements to search result score badges:

* Added a `title` tooltip to the AI-powered score badge, explaining that it is ranked by an LLM based on semantic understanding, with a score range from 0% to 100%.
* Added a `title` tooltip to the OpenSearch score badge, explaining that it is based on keyword matching and text analysis, with a score range from 0% to 100%.