### PR TITLE
Add ref in `useSearchResults` hook to prevent concurrent searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # EOSC Data Commons Frontend
 
-A web application for searching scientific datasets using natural language queries. This application works with the [EOSC Data Commons MCP server](https://github.com/EOSC-Data-Commons/data-commons-mcp) to help you discover scientific datasets through AI-powered search.
+A web application for searching scientific datasets using natural language queries. This application works with the [EOSC Data Commons Search server](https://github.com/EOSC-Data-Commons/data-commons-search) to help you discover scientific datasets through AI-powered search.
 
 ## What You Need First
 
@@ -62,11 +62,11 @@ Install dependencies:
 npm install
 ```
 
-### Step 2: Set Up the Backend (EOSC Data Commons MCP server)
+### Step 2: Set Up the Backend (EOSC Data Commons search server)
 
-Follow the instructions in the backend [README](https://github.com/EOSC-Data-Commons/data-commons-mcp) to set up and run the server. The frontend expects the backend to be running on port 8000 by default.
+Follow the instructions in the backend [README](https://github.com/EOSC-Data-Commons/data-commons-search) to set up and run the server. The frontend expects the backend to be running on port 8000 by default.
 
-> **Note:**
+> [!NOTE]
 > If you are running the backend with Docker and encounter an error of HTTP 401, related to `SEARCH_API_KEY=SECRET_KEY_YOU_CAN_USE_IN_FRONTEND_TO_AVOID_SPAM`, try removing or commenting out the `SEARCH_API_KEY` line in your backend `.env` file. The backend does not require this key unless you want to restrict API access.
 
 ### Step 3: Start the Frontend
@@ -120,7 +120,9 @@ docker run -p 5173:80 ghcr.io/eosc-data-commons/matchmaker-frontend:latest
 - The app will be available at http://localhost:5173
 - Make sure your backend server is running and accessible to the container (default: http://localhost:8000)
 
-> **Note:** If running backend and frontend in separate containers, you may need to adjust CORS or network settings for them to communicate.
+> [!NOTE]
+>
+> If running backend and frontend in separate containers, you may need to adjust CORS or network settings for them to communicate.
 
 
 ## How to Search

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -1,4 +1,4 @@
-import {useState, useCallback} from 'react';
+import {useState, useCallback, useRef} from 'react';
 import {useNavigate} from 'react-router';
 import type {BackendSearchResponse} from '../types/commons';
 import {searchWithBackend} from '../lib/api';
@@ -20,20 +20,23 @@ export const useSearchResults = (query: string, model: string): UseSearchResults
     const [loading, setLoading] = useState(true);
     const [isProcessing, setIsProcessing] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const isSearchingRef = useRef(false);
 
     const performSearch = useCallback(async () => {
-        if (!query) {
-            navigate('/');
-            return;
-        }
-
-        setLoading(true);
-        setIsProcessing(false);
-        setError(null);
-        setInitialResults(null);
-        setRerankedResults(null);
-
+        if (isSearchingRef.current) return; // Prevent concurrent searches
+        isSearchingRef.current = true;
         try {
+            if (!query) {
+                navigate('/');
+                return;
+            }
+
+            setLoading(true);
+            setIsProcessing(false);
+            setError(null);
+            setInitialResults(null);
+            setRerankedResults(null);
+
             await searchWithBackend(query, model, {
                 onSearchData: (data) => {
                     setInitialResults(data);
@@ -43,21 +46,20 @@ export const useSearchResults = (query: string, model: string): UseSearchResults
                 },
                 onRerankedData: (data) => {
                     setRerankedResults(data);
-                    setIsProcessing(false);
                 },
                 onError: (err) => {
                     console.error("Search stream error:", err);
                     setError(err.message);
-                    setLoading(false);
-                    setIsProcessing(false);
                 },
             });
             addToSearchHistory(query);
         } catch (err) {
             console.error("Search error:", err);
             setError(err instanceof Error ? err.message : "An unknown error occurred.");
+        } finally {
             setLoading(false);
             setIsProcessing(false);
+            isSearchingRef.current = false;
         }
     }, [query, model, navigate]);
 


### PR DESCRIPTION
React triggers `useEffect` twice in dev to force us to handle these cases properly.

Also moved the `setLoading` and `setIsProcessing` to a `finally` block instead of having to put them in every possible branches

Updated readme