### PR TITLE
Update FILEMETRIX_BASE URL for API endpoint

### DIFF
--- a/src/lib/dispatcherApi.ts
+++ b/src/lib/dispatcherApi.ts
@@ -11,7 +11,7 @@ import {fetchWithTimeout} from './utils';
 // Use proxy to avoid CORS issues
 const API_BASE = '/api/player';
 const METADATA_ENDPOINT = '/anon_requests/metadata_rocrate/';
-const FILEMETRIX_BASE = 'https://filemetrix.labs.dansdemo.nl/api/v1';
+const FILEMETRIX_BASE = 'https://filemetrix.eosc-data-commons.dansdemo.nl/api/v1';
 
 /**
  * Fetch files from FileMetrix API for a given dataset handle


### PR DESCRIPTION
I moved filemetrix to new domain so we need to update the API URL