### PR TITLE
improve fetchConversations with ref

### DIFF
--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -92,6 +92,12 @@ const ChatPage: FC = () => {
         }
     }, [user?.sub]);
 
+    // Keep a ref to the latest fetchConversations so async flows (e.g. a chat
+    // started from the landing page before `user` has loaded) refresh the
+    // sidebar using the current closure instead of a stale one.
+    const fetchConversationsRef = useRef(fetchConversations);
+    fetchConversationsRef.current = fetchConversations;
+
     useEffect(() => {
         fetchConversations();
     }, [fetchConversations]);
@@ -361,7 +367,7 @@ const ChatPage: FC = () => {
             console.error("Failed to send message", e);
             setIsSending(false);
         } finally {
-            fetchConversations();
+            fetchConversationsRef.current();
         }
     };
 


### PR DESCRIPTION
This pull request updates the `req-packager` submodule and improves how conversation fetching is handled in the `ChatPage` component to prevent issues with stale closures in asynchronous flows.

**Dependency update:**

* Updated the `req-packager` submodule to the latest commit, ensuring the project uses the most recent version.

**React state management improvements:**

* Added a `fetchConversationsRef` using `useRef` to always reference the latest `fetchConversations` function, preventing issues with stale closures during asynchronous operations.
* Updated the message sending logic to use `fetchConversationsRef.current()` instead of the possibly stale `fetchConversations` function, ensuring the sidebar refreshes with the current closure.