### PR TITLE
Adjust chart layouts for dynamic scaling and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.7] - 26/06/2026
+
+- Added updated more in-depth stats on the landing page.
+
 ## [0.8.6] - 26/06/2026
 
 - Fixed a bug where starting a new chat from the landing page did not update the conversation sidebar or chat title

--- a/src/components/RepositoryStats.tsx
+++ b/src/components/RepositoryStats.tsx
@@ -19,7 +19,12 @@ const ACCENT_BLUE = "#009FE3";
 const MID_BLUE = "#3b7dd8";
 const GRAY = "#646363";
 
-const MAX_SUBJECTS = 8;
+// Floor for how many subjects to show; the actual count scales up to fill the
+// height of the repository chart (see subjectData) so the two columns stay
+// balanced as repositories are added.
+const MIN_SUBJECTS = 8;
+const REPO_ROW_HEIGHT = 48;
+const SUBJECT_ROW_HEIGHT = 36;
 
 const formatNumber = (n: number) => n.toLocaleString();
 
@@ -140,12 +145,23 @@ export const RepositoryStats = () => {
     const effectiveCode = selectedCode ?? activeRepos[0]?.code ?? null;
     const selectedRepo = activeRepos.find((r) => r.code === effectiveCode) ?? null;
 
+    // Height of the repository chart drives the layout; the subjects chart
+    // matches it so the right column fills the same vertical space.
+    const repoChartHeight = Math.max(repoData.length * REPO_ROW_HEIGHT, 240);
+
     const subjectData: SubjectBarDatum[] = useMemo(() => {
         if (!selectedRepo) return [];
+        // Show as many subjects as fit the repo chart's height, but never fewer
+        // than MIN_SUBJECTS and never more than the API actually returns.
+        const fitCount = Math.round(repoChartHeight / SUBJECT_ROW_HEIGHT);
+        const maxSubjects = Math.min(
+            selectedRepo.top_subjects.length,
+            Math.max(fitCount, MIN_SUBJECTS)
+        );
         return selectedRepo.top_subjects
-            .slice(0, MAX_SUBJECTS)
+            .slice(0, maxSubjects)
             .map((s) => ({subject: s.subject, count: s.count}));
-    }, [selectedRepo]);
+    }, [selectedRepo, repoChartHeight]);
 
     if (loading) {
         return (
@@ -192,7 +208,7 @@ export const RepositoryStats = () => {
                     <p className="text-xs font-light text-[#646363] mb-4">
                         Select a repository to explore its top subjects
                     </p>
-                    <ResponsiveContainer width="100%" height={Math.max(repoData.length * 48, 240)}>
+                    <ResponsiveContainer width="100%" height={repoChartHeight}>
                         <BarChart
                             layout="vertical"
                             data={repoData}
@@ -203,7 +219,7 @@ export const RepositoryStats = () => {
                             <YAxis
                                 type="category"
                                 dataKey="code"
-                                width={70}
+                                width={96}
                                 tick={<ClickableTick selectedCode={effectiveCode} onSelect={setSelectedCode}/>}
                                 axisLine={false}
                                 tickLine={false}
@@ -244,7 +260,8 @@ export const RepositoryStats = () => {
                         {selectedRepo?.name ?? ""}
                     </p>
                     {subjectData.length > 0 ? (
-                        <ResponsiveContainer width="100%" height={Math.max(subjectData.length * 36, 240)}>
+                        <ResponsiveContainer width="100%"
+                                             height={Math.max(subjectData.length * SUBJECT_ROW_HEIGHT, 240)}>
                             <BarChart
                                 layout="vertical"
                                 data={subjectData}


### PR DESCRIPTION
This pull request updates the repository stats display to provide more in-depth and visually balanced statistics on the landing page. The main improvements ensure that the subjects chart dynamically matches the repository chart's height, leading to a more consistent and informative UI, especially as repositories are added.

**UI Improvements for Repository and Subject Stats:**

* The number of subjects shown in the subjects chart now scales dynamically to match the height of the repository chart, ensuring both columns stay visually balanced regardless of the number of repositories. The minimum number of subjects displayed is set to 8, but it can increase as needed to fill the chart area, up to the number available from the API. [[1]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7L22-R27) [[2]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7R148-R164)
* The height of both the repository and subject charts is now consistently calculated based on the number of items and their respective row heights, improving layout stability and appearance. [[1]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7R148-R164) [[2]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7L195-R211) [[3]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7L247-R264)
* The Y-axis width for repository codes has been increased for better readability.

**Documentation:**

* The `CHANGELOG.md` file has been updated to reflect these new, more in-depth stats on the landing page.