### PR TITLE
Enhance text rendering and improve NoResultsError handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.8] - 30/06/2026
+
+- Fixed the search results page showing a red "Search Error / No search results received" panel when a query returned no
+  datasets (e.g. when the backend answered conversationally instead of returning results).
+
 ## [0.8.7] - 26/06/2026
 
 - Added updated more in-depth stats on the landing page.

--- a/src/components/SearchResultItem.tsx
+++ b/src/components/SearchResultItem.tsx
@@ -94,7 +94,7 @@ export const SearchResultItem = ({hit, isAiRanked = false, isLoggedIn = false}: 
                 : 'bg-gray-100 border-gray-300'
         }`}>
             <div className="flex flex-col sm:flex-row justify-between items-start mb-3">
-                <h3 className="text-lg font-semibold text-gray-900 pr-4 mb-2 sm:mb-0">
+                <h3 className="text-lg font-semibold text-gray-900 pr-4 mb-2 sm:mb-0 min-w-0 break-words">
                     {hit.title}
                 </h3>
                 {isAiRanked && hit.score !== undefined && (
@@ -122,7 +122,7 @@ export const SearchResultItem = ({hit, isAiRanked = false, isLoggedIn = false}: 
             </div>
 
             <div className="mb-4">
-                <p className="text-gray-700 leading-relaxed inline">
+                <p className="text-gray-700 leading-relaxed inline break-words">
                     {visibleDescription}
                 </p>
                 {isDescTruncated && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -46,6 +46,19 @@ export class ServerError extends Error {
     }
 }
 
+/**
+ * Thrown when the stream completes without any dataset results (e.g. the agent
+ * answered conversationally via TEXT_MESSAGE_CHUNK events instead of calling a
+ * search tool). This is not a failure — it should surface as a friendly
+ * "no results" view, not a red error.
+ */
+export class NoResultsError extends Error {
+    constructor(message?: string) {
+        super(message || "No search results received");
+        this.name = "NoResultsError";
+    }
+}
+
 export interface SearchRequest {
     items: Array<{
         type: string;
@@ -217,7 +230,7 @@ export const handleStream = async (
         // If we encountered a RUN_ERROR, throw it
         if (runError) throw runError;
 
-        if (!latestResults) throw new Error('No search results received');
+        if (!latestResults) throw new NoResultsError();
         return latestResults;
     } finally {
         reader.releaseLock();

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -596,7 +596,7 @@ const ChatPage: FC = () => {
                                     <div key={index}
                                          className={`w-full flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}>
                                         <div
-                                            className={`group flex gap-3 max-w-[85%] ${msg.sender === 'user' ? 'flex-row-reverse' : ''}`}>
+                                            className={`group flex gap-3 max-w-[85%] min-w-0 ${msg.sender === 'user' ? 'flex-row-reverse' : ''}`}>
                                             {/* Avatar */}
                                             <div
                                                 className={`w-8 h-8 rounded-full shrink-0 flex items-center justify-center shadow-sm mt-1 overflow-hidden ${msg.sender === 'user' ? 'bg-[#002337] text-white text-sm font-medium' : 'bg-white border border-gray-100 p-1'}`}>
@@ -608,7 +608,7 @@ const ChatPage: FC = () => {
                                                 )}
                                             </div>
                                             <div
-                                                className={`rounded-2xl px-5 py-3 shadow-sm text-[15px] ${
+                                                className={`rounded-2xl px-5 py-3 shadow-sm text-[15px] min-w-0 break-words ${
                                                     msg.sender === 'user'
                                                         ? 'bg-blue-600 text-white rounded-tr-sm'
                                                         : 'bg-white border border-gray-200 text-gray-800 rounded-tl-sm whitespace-pre-wrap'

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,7 +13,7 @@ import {useSearchResults} from "../hooks/useSearchResults.ts";
 import {useCombinedDatasets} from "../hooks/useCombinedDatasets.ts";
 import {useFilteredDatasets} from "../hooks/useFilteredDatasets.ts";
 import dataCommonsIconBlue from '@/assets/data-commons-icon-blue.svg';
-import {RateLimitError, ServerError} from "../lib/api.ts";
+import {RateLimitError, ServerError, NoResultsError} from "../lib/api.ts";
 import {useAuth} from "@/hooks/useAuth.ts";
 import {SearchFeedback} from "../components/SearchFeedback.tsx";
 
@@ -87,6 +87,11 @@ export const SearchPage = () => {
     const hasInitialResults = initialResults !== null;
     const isRateLimit = error instanceof RateLimitError;
     const isServerError = error instanceof ServerError;
+    // An empty result set is not a failure — show the friendly no-results view,
+    // not the red error panel.
+    const isNoResults = error instanceof NoResultsError;
+    // "Real" errors that warrant the red error panel (rate limit, server, run error).
+    const hasError = !!error && !isNoResults;
 
     // Helper to determine error UI properties
     const getErrorState = () => {
@@ -133,7 +138,7 @@ export const SearchPage = () => {
 
             <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 {/* Summary - show reranked summary if available */}
-                {!loading && !error && hasRerankedResults && rerankedResults.summary && (
+                {!loading && !hasError && hasRerankedResults && rerankedResults.summary && (
                     <div className="mb-6 p-4 bg-white rounded-lg shadow-sm border border-blue-200">
                         <h3 className="text-lg font-semibold text-gray-900 mb-2">AI-Generated Summary</h3>
                         <p className="text-gray-700">{rerankedResults.summary}</p>
@@ -142,7 +147,7 @@ export const SearchPage = () => {
 
                 <div className="flex flex-col lg:flex-row gap-8">
                     {/* Filter Panel - Only show when AI results are ready */}
-                    {!loading && !error && hasRerankedResults && Object.keys(aggregations).length > 0 && (
+                    {!loading && !hasError && hasRerankedResults && Object.keys(aggregations).length > 0 && (
                         <FilterPanel
                             aggregations={aggregations}
                             onFilterChange={handleFilterChange}
@@ -155,7 +160,7 @@ export const SearchPage = () => {
                         <LoadingOverlay show={loading}/>
 
                         {/* Error state inline */}
-                        {!loading && error && (
+                        {!loading && hasError && (
                             <div
                                 className={`p-6 bg-white rounded-lg shadow-sm border border-${errorState.color}-200 text-center space-y-4`}>
                                 <ErrorIcon className={`h-12 w-12 text-${errorState.color}-500 mx-auto`}/>
@@ -175,13 +180,13 @@ export const SearchPage = () => {
                         )}
 
                         {/* Processing indicator - shows when initial results exist but reranking is in progress */}
-                        <ProcessingIndicator show={!loading && !error && hasInitialResults && isProcessing}/>
+                        <ProcessingIndicator show={!loading && !hasError && hasInitialResults && isProcessing}/>
 
                         {/* Results section */}
                         <div
                             className={loading ? 'opacity-0 pointer-events-none select-none' : 'opacity-100 transition-opacity'}
                             aria-hidden={loading}>
-                            {!loading && !error && (
+                            {!loading && !hasError && (
                                 datasets.length === 0 ? (
                                     <NoResultsMessage/>
                                 ) : (


### PR DESCRIPTION
This pull request improves the user experience on the search results page by distinguishing between real errors and cases where no datasets are returned (such as when the backend responds conversationally). It introduces a new `NoResultsError` to ensure that an empty result set shows a friendly "no results" message instead of a red error panel. Additionally, several UI components have been updated to better handle long text and maintain layout integrity.

**Error handling improvements:**

* Added a new `NoResultsError` class in `src/lib/api.ts` to represent cases where the search completes without any dataset results, ensuring these are not treated as failures.
* Updated the `handleStream` function in `src/lib/api.ts` to throw `NoResultsError` instead of a generic error when no results are received.
* Modified `src/pages/SearchPage.tsx` to import and use `NoResultsError`, updating error state logic so that only genuine errors (not empty results) trigger the red error panel. All UI components that depend on error state now use the new logic. [[1]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L16-R16) [[2]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563R90-R94) [[3]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L136-R141) [[4]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L145-R150) [[5]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L158-R163) [[6]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L178-R189)

**UI and layout improvements:**

* Improved text wrapping and layout resilience in `SearchResultItem` (`src/components/SearchResultItem.tsx`), chat messages (`src/pages/ChatPage.tsx`), and other areas by adding `min-w-0` and `break-words` to relevant elements. This prevents overflow and ensures long text is displayed gracefully. [[1]](diffhunk://#diff-e99b0d00ea1f6db3ed4a7f2d86dc919322a2a5d126b303fa315f2d5f3e9acf2cL97-R97) [[2]](diffhunk://#diff-e99b0d00ea1f6db3ed4a7f2d86dc919322a2a5d126b303fa315f2d5f3e9acf2cL125-R125) [[3]](diffhunk://#diff-58006f9fdcf04a8628c06774083a96a708a8509642e22ad16f42e449afcda96fL599-R599) [[4]](diffhunk://#diff-58006f9fdcf04a8628c06774083a96a708a8509642e22ad16f42e449afcda96fL611-R611)

**Documentation:**

* Updated `CHANGELOG.md` to document the fix for the search results page incorrectly showing a red error panel when no datasets are returned.