### PR TITLE
Update default model to cesnet/agentic and set en-GB locale

### DIFF
--- a/src/components/FilterSection.tsx
+++ b/src/components/FilterSection.tsx
@@ -41,7 +41,7 @@ export const FilterSection = ({
                             />
                             <label htmlFor={`${filterKey}-${bucket.key}`}
                                    className="ml-3 text-sm text-gray-600 flex-grow">
-                                {bucket.label} ({bucket.doc_count.toLocaleString()})
+                                {bucket.label} ({bucket.doc_count.toLocaleString("en-GB")})
                             </label>
                         </div>
                     ))}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -23,7 +23,7 @@ export const Pagination = ({page, size, total, onPageChange}: {
                 Previous
             </button>
             <span className="text-sm text-gray-600">
-                Page {page} of {totalPages.toLocaleString()}
+                Page {page} of {totalPages.toLocaleString("en-GB")}
             </span>
             <button
                 onClick={() => handlePageClick(page + 1)}

--- a/src/components/RepositoryStats.tsx
+++ b/src/components/RepositoryStats.tsx
@@ -26,7 +26,7 @@ const MIN_SUBJECTS = 8;
 const REPO_ROW_HEIGHT = 48;
 const SUBJECT_ROW_HEIGHT = 36;
 
-const formatNumber = (n: number) => n.toLocaleString();
+const formatNumber = (n: number) => n.toLocaleString("en-GB");
 
 const truncate = (text: string, max = 28) =>
     text.length > max ? `${text.slice(0, max - 1)}…` : text;

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -7,15 +7,16 @@ import useMatomo from "../hooks/useMatomo";
 
 const SHOW_MODEL_SELECTOR = import.meta.env.VITE_SHOW_MODEL_SELECTOR === 'true';
 
-const DEFAULT_MODEL = "cesnet/qwen3-coder";
+const DEFAULT_MODEL = "cesnet/agentic";
 
 const models = [
     "openai/gpt-4.1",
     "mistralai/mistral-large-latest",
     "groq/moonshotai/kimi-k2-instruct",
-    "cesnet/qwen3-coder",
-    "cesnet/gpt-oss-120b",
-    "cesnet/deepseek-v3.2-thinking"
+    "cesnet/agentic",
+    "cesnet/coder",
+    "cesnet/mini",
+    "cesnet/thinker"
 ];
 
 interface SearchInputProps {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -92,7 +92,7 @@ export interface SSEEventHandler {
 
 export const searchWithBackend = async (
     query: string,
-    model: string = 'cesnet/qwen3-coder',
+    model: string = 'cesnet/agentic',
     handlers: SSEEventHandler,
     timeoutMs: number = 60000 // Default 1 minute timeout
 ): Promise<BackendSearchResponse> => {
@@ -239,7 +239,7 @@ export const handleStream = async (
 
 export const sendChatMessage = async (
     messages: Message[],
-    model: string = 'cesnet/qwen3-coder',
+    model: string = 'cesnet/agentic',
     threadId: string | undefined,
     onEvent: (event: SSEEvent) => void,
     onError: (error: Error) => void,

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -198,7 +198,7 @@ const ChatPage: FC = () => {
 
             // Wait slightly for layout to settle before sending
             setTimeout(() => {
-                handleSendMessage(initialQuery, initialModel || 'cesnet/qwen3-coder');
+                handleSendMessage(initialQuery, initialModel || 'cesnet/agentic');
             }, 100);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -177,7 +177,7 @@ export const LandingPage = () => {
                                 {dataCards.map((card, index) => (
                                     <div
                                         key={index}
-                                        onClick={() => handleSearch(card, "cesnet/qwen3-coder")}
+                                        onClick={() => handleSearch(card, "cesnet/agentic")}
                                         className="bg-white border border-eosc-border rounded-xl p-6 min-h-[75px] flex items-center justify-center cursor-pointer hover:bg-gray-50 hover:border-eosc-light-blue transition-colors"
                                     >
                                         <p className="text-sm font-light text-black text-center">

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -24,7 +24,7 @@ export const SearchPage = () => {
     const [showInitialResults, setShowInitialResults] = useState(false);
 
     const query = searchParams.get('q') || '';
-    const model = searchParams.get('model') || 'cesnet/qwen3-coder';
+    const model = searchParams.get('model') || 'cesnet/agentic';
 
     // Custom hooks for data management
     const {


### PR DESCRIPTION
This pull request updates the default and fallback language model throughout the application from `cesnet/qwen3-coder` to `cesnet/agentic`, and standardizes number formatting to use British English locale (`en-GB`) for consistency in UI display. The most important changes are:

**Default Model Update:**

* Changed the default and fallback language model from `cesnet/qwen3-coder` to `cesnet/agentic` in the search input, backend API calls, chat page initialization, landing page quick search, and search page query parameter handling. This ensures the new model is used across all relevant user interactions. [[1]](diffhunk://#diff-d5714b989c11fe0b2cc0b189085317470cda1d5c5fae91c4cb05cda2955a72b3L10-R19) [[2]](diffhunk://#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0dL95-R95) [[3]](diffhunk://#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0dL242-R242) [[4]](diffhunk://#diff-58006f9fdcf04a8628c06774083a96a708a8509642e22ad16f42e449afcda96fL201-R201) [[5]](diffhunk://#diff-8582e44c9a5547798894a6848ebd82dd4d94aa7322a51bb3a11f35cb4c247ed5L180-R180) [[6]](diffhunk://#diff-741159ad29e21776ad33d2e4fe2775ae9a11542ff7e6769bb7a87d224370c563L27-R27)

**Model Selector Options:**

* Updated the available model list in `SearchInput` to reflect the new default and added additional CESNET models, replacing the old ones.

**Number Formatting Consistency:**

* Standardized number formatting in UI components (`FilterSection`, `Pagination`, and `RepositoryStats`) to use the `"en-GB"` locale, ensuring consistent display of numbers with appropriate thousands separators. [[1]](diffhunk://#diff-d59728004450efbfcd9abb2c8fbbe8fcd2400a827fe3f01d3daf0773b780f60dL44-R44) [[2]](diffhunk://#diff-b436247c804ea29890042d9594065a5b7d2c3c5e128da1228030c1a81af6d5caL26-R26) [[3]](diffhunk://#diff-5253308fffcadb8216dab6819a2ed046ef745ee22f0f79a4924cc409b1a3ffe7L29-R29)